### PR TITLE
connected db

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -8,8 +8,6 @@ import Boards from "./pages/Boards";
 import Home from "./pages/Home";
 import About from "./pages/About";
 import Board from "./components/Board";
-import { connect } from 'react-redux';
-// https://www.npmjs.com/package/react-smooth-dnd - drag and drop
 
 
 function App() {
@@ -27,10 +25,5 @@ function App() {
     </div>
   );
 }
-
-
-const mapStateToProps = state => ({
-  cards: state.cards
-})
 
 export default App;

--- a/frontend/src/components/Board.js
+++ b/frontend/src/components/Board.js
@@ -1,15 +1,21 @@
 // import the things you need
 import { useState, useEffect } from 'react';
+import { useParams } from 'react-router-dom';
 import { Button, Modal } from 'react-bootstrap';
 import NewCalCard from './NewCalCard';
 import CalypsoCard from "./CalypsoCard";
 
-const Board = () => {
+const Board = ({ board, title }) => {
 
     // get the cards (and maybe columns?)
     const [calCards, setCalCards] = useState(null);
     const [columns, setColumns] = useState(null);
-    const URL = "";
+
+    const { id } = useParams();
+    console.log(useParams());
+
+    const URL = `https://calypso-back-end.onrender.com/boards/${id}`; // fetch a board by id
+
     useEffect(() => {
         console.log("board_ useEffect ran");
         const fetchBoard = async() => {
@@ -24,15 +30,15 @@ const Board = () => {
     }, []);
 
     // list the cards
-    let calCardList;
+    // let calCardList;
 
-    if (calCards) {
-        calCardList = calCards.map((calCard, index) => {
-          return (
-              <CalypsoCard key={index} calCard={calCard} />
-          );
-        });
-    };
+    // if (calCards) {
+    //     calCardList = calCards.map((calCard, index) => {
+    //       return (
+    //           <CalypsoCard key={index} calCard={calCard} />
+    //       );
+    //     });
+    // };
 
     // for add new card modal
     const [showModal, setShowModal] = useState(false);
@@ -46,7 +52,7 @@ const Board = () => {
     // board_ page
     return (
         <div>
-            <h1>My Board Page</h1>
+            <h1>My Board</h1>
             <h3>My Cards</h3>
             {/* existing cards */}
             <CalypsoCard title="this is a card" />

--- a/frontend/src/components/Board.js
+++ b/frontend/src/components/Board.js
@@ -44,7 +44,7 @@ const Board = (props) => {
     // board_ page
     return (
         <div>
-            <h1>{myBoard.title}</h1>
+            {myBoard ? <h1>{myBoard.title}</h1> : <h2>LOADING.. </h2>}
             <h3>My Cards</h3>
             {/* existing cards */}
             <CalypsoCard title="this is a card" />

--- a/frontend/src/components/Board.js
+++ b/frontend/src/components/Board.js
@@ -8,24 +8,24 @@ import CalypsoCard from "./CalypsoCard";
 const Board = (props) => {
 
     // get the cards
-    const [calCards, setCalCards] = useState(null);
+    const [myBoard, setMyBoard] = useState(null);
     // const [columns, setColumns] = useState(null);
     const [newCardData, setNewCardData] = useState({ title: '', tasks: [] });
 
 
-    const { boardId } = useParams();
-    console.log('boardId: ', boardId);
+    const { id } = useParams();
+    console.log('id: ', id);
 
-    const URL = `https://calypso-back-end.onrender.com/boards/${boardId}`; // fetch a board by id
+    const URL = `https://calypso-back-end.onrender.com/boards/${id}`; // fetch a board by id
 
     useEffect(() => {
         console.log("board_ useEffect ran");
         const fetchBoard = async() => {
             try {
                 let responseData = await fetch(URL);
-                let allCalCards = await responseData.json();
-                console.log(allCalCards);
-                setCalCards(allCalCards);
+                let boardData = await responseData.json();
+                console.log('boardData: ', boardData);
+                setMyBoard(boardData);
             } catch (error) {}
         };
         fetchBoard()
@@ -44,7 +44,7 @@ const Board = (props) => {
     // board_ page
     return (
         <div>
-            <h1>My Board</h1>
+            <h1>{myBoard.title}</h1>
             <h3>My Cards</h3>
             {/* existing cards */}
             <CalypsoCard title="this is a card" />
@@ -58,7 +58,7 @@ const Board = (props) => {
                     <Modal.Title>Create a New Card</Modal.Title>
                 </Modal.Header>
             <Modal.Body>
-                <NewCalCard id={boardId} />
+                <NewCalCard id={id} />
             </Modal.Body>
             <Modal.Footer>
                 <Button variant="secondary" onClick={handleCloseModal}>

--- a/frontend/src/components/Board.js
+++ b/frontend/src/components/Board.js
@@ -5,16 +5,18 @@ import { Button, Modal } from 'react-bootstrap';
 import NewCalCard from './NewCalCard';
 import CalypsoCard from "./CalypsoCard";
 
-const Board = ({ board, title }) => {
+const Board = (props) => {
 
-    // get the cards (and maybe columns?)
+    // get the cards
     const [calCards, setCalCards] = useState(null);
-    const [columns, setColumns] = useState(null);
+    // const [columns, setColumns] = useState(null);
+    const [newCardData, setNewCardData] = useState({ title: '', tasks: [] });
 
-    const { id } = useParams();
-    console.log(useParams());
 
-    const URL = `https://calypso-back-end.onrender.com/boards/${id}`; // fetch a board by id
+    const { boardId } = useParams();
+    console.log('boardId: ', boardId);
+
+    const URL = `https://calypso-back-end.onrender.com/boards/${boardId}`; // fetch a board by id
 
     useEffect(() => {
         console.log("board_ useEffect ran");
@@ -29,23 +31,13 @@ const Board = ({ board, title }) => {
         fetchBoard()
     }, []);
 
-    // list the cards
-    // let calCardList;
-
-    // if (calCards) {
-    //     calCardList = calCards.map((calCard, index) => {
-    //       return (
-    //           <CalypsoCard key={index} calCard={calCard} />
-    //       );
-    //     });
-    // };
-
     // for add new card modal
     const [showModal, setShowModal] = useState(false);
     const handleShowModal = () => {
         setShowModal(true);
     };
     const handleCloseModal = () => {
+        setNewCardData({ title: '', tasks: [] });
         setShowModal(false);
     };
 
@@ -66,7 +58,7 @@ const Board = ({ board, title }) => {
                     <Modal.Title>Create a New Card</Modal.Title>
                 </Modal.Header>
             <Modal.Body>
-                <NewCalCard />
+                <NewCalCard id={boardId} />
             </Modal.Body>
             <Modal.Footer>
                 <Button variant="secondary" onClick={handleCloseModal}>

--- a/frontend/src/components/Board.js
+++ b/frontend/src/components/Board.js
@@ -5,18 +5,17 @@ import { Button, Modal } from 'react-bootstrap';
 import NewCalCard from './NewCalCard';
 import CalypsoCard from "./CalypsoCard";
 
+
 const Board = (props) => {
 
-    // get the cards
+    // get the board
     const [myBoard, setMyBoard] = useState(null);
-    // const [columns, setColumns] = useState(null);
-    const [newCardData, setNewCardData] = useState({ title: '', tasks: [] });
-
+    const [newCardData, setNewCardData] = useState(null);
 
     const { id } = useParams();
     console.log('id: ', id);
 
-    const URL = `https://calypso-back-end.onrender.com/boards/${id}`; // fetch a board by id
+    const URL = `https://calypso-back-end.onrender.com/boards/${id}`; // board_id routes
 
     useEffect(() => {
         console.log("board_ useEffect ran");
@@ -45,9 +44,6 @@ const Board = (props) => {
     return (
         <div>
             {myBoard ? <h1>{myBoard.title}</h1> : <h2>LOADING.. </h2>}
-            <h3>My Cards</h3>
-            {/* existing cards */}
-            <CalypsoCard title="this is a card" />
 
             {/* new card form */}
             <Button variant="primary" onClick={handleShowModal}>
@@ -57,15 +53,19 @@ const Board = (props) => {
                 <Modal.Header closeButton>
                     <Modal.Title>Create a New Card</Modal.Title>
                 </Modal.Header>
-            <Modal.Body>
-                <NewCalCard id={id} />
-            </Modal.Body>
-            <Modal.Footer>
-                <Button variant="secondary" onClick={handleCloseModal}>
-                    Cancel
-                </Button>
-            </Modal.Footer>
-            </Modal>       
+                <Modal.Body>
+                    <NewCalCard id={id} />
+                </Modal.Body>
+                <Modal.Footer>
+                    <Button variant="secondary" onClick={handleCloseModal}>
+                        Cancel
+                    </Button>
+                </Modal.Footer>
+            </Modal>  
+            
+            {/* existing cards */}
+            <CalypsoCard title="this is a card" />
+                 
         </div>
     )
 };

--- a/frontend/src/components/BoardIcon.js
+++ b/frontend/src/components/BoardIcon.js
@@ -1,8 +1,10 @@
+// import what you need
 import { Card, Container, Row, Col } from 'react-bootstrap';
 import { Link } from 'react-router-dom';
 
+
 const BoardIcon = ({ boards }) => {
-    console.log('boards: ', boards)
+    
     // display board icon
     return (
         <Container>

--- a/frontend/src/components/BoardIcon.js
+++ b/frontend/src/components/BoardIcon.js
@@ -2,6 +2,7 @@ import { Card, Container, Row, Col } from 'react-bootstrap';
 import { Link } from 'react-router-dom';
 
 const BoardIcon = ({ boards }) => {
+    console.log('boards: ', boards)
     // display board icon
     return (
         <Container>
@@ -9,7 +10,7 @@ const BoardIcon = ({ boards }) => {
             {/* map through boards, display title and make each board icon linkable to its id (show page) */}
             {boards.map((board, index) => (
                 <Col xs={12} md={4} key={index}>
-                    <Link to={`/boards/${board.id}`} style={{ textDecoration: 'none' }}>
+                    <Link to={`/boards/${board._id}`} style={{ textDecoration: 'none' }}>
                         <Card>
                         <Card.Title>{board.title}</Card.Title>
                         <Card.Img src="" />

--- a/frontend/src/components/BoardIcon.js
+++ b/frontend/src/components/BoardIcon.js
@@ -1,0 +1,26 @@
+import { Card, Container, Row, Col } from 'react-bootstrap';
+import { Link } from 'react-router-dom';
+
+const BoardIcon = ({ boards }) => {
+    // display board icon
+    return (
+        <Container>
+            <Row>
+            {/* map through boards, display title and make each board icon linkable to its id (show page) */}
+            {boards.map((board, index) => (
+                <Col xs={12} md={4} key={index}>
+                    <Link to={`/boards/${board.id}`} style={{ textDecoration: 'none' }}>
+                        <Card>
+                        <Card.Title>{board.title}</Card.Title>
+                        <Card.Img src="" />
+                        <h3>image</h3>
+                        </Card>
+                    </Link>
+                 </Col>
+             ))}
+            </Row>
+        </Container>
+    )
+};
+
+export default BoardIcon;

--- a/frontend/src/components/CalypsoCard.js
+++ b/frontend/src/components/CalypsoCard.js
@@ -7,7 +7,7 @@ import NewTask from './NewTask';
 
 function CalypsoCard({ title }) {
     
-    // for add new task modal
+    // add new task modal
     const [showModal, setShowModal] = useState(false);
     const handleShowModal = () => {
         setShowModal(true);
@@ -19,28 +19,28 @@ function CalypsoCard({ title }) {
     return (
         <div>
             <Container>
-            <Card style={{width: "300px"}}>
-                <Card.Title>{title}</Card.Title>
-                <Task task="this is a task" />
-            <Card.Footer>
-            <Button variant="primary" onClick={handleShowModal}>
-                    Add New Task
-            </Button>
-            </Card.Footer>
-            </Card>
-            <Modal show={showModal} onHide={handleCloseModal}>
-                <Modal.Header closeButton>
-                    <Modal.Title>Create a New Task</Modal.Title>
-                </Modal.Header>
-            <Modal.Body>
-                <NewTask />
-            </Modal.Body>
-            <Modal.Footer>
-                <Button variant="secondary" onClick={handleCloseModal}>
-                    Cancel
-                </Button>
-            </Modal.Footer>
-            </Modal>
+                <Card style={{width: "300px"}}>
+                    <Card.Title>{title}</Card.Title>
+                    <Task task="this is a task" />
+                    <Card.Footer>
+                    <Button variant="primary" onClick={handleShowModal}>
+                            Add New Task
+                    </Button>
+                    </Card.Footer>
+                </Card>
+                <Modal show={showModal} onHide={handleCloseModal}>
+                    <Modal.Header closeButton>
+                        <Modal.Title>Create a New Task</Modal.Title>
+                    </Modal.Header>
+                    <Modal.Body>
+                        <NewTask />
+                    </Modal.Body>
+                    <Modal.Footer>
+                        <Button variant="secondary" onClick={handleCloseModal}>
+                            Cancel
+                        </Button>
+                    </Modal.Footer>
+                </Modal>
             </Container>
         </div> 
     )

--- a/frontend/src/components/Card.js
+++ b/frontend/src/components/Card.js
@@ -1,7 +1,0 @@
-function Card(props) {
-    return (
-        <h1>Card Component</h1>
-    )
-};
-
-export default Card;

--- a/frontend/src/components/NewBoard.js
+++ b/frontend/src/components/NewBoard.js
@@ -9,20 +9,34 @@ const NewBoard = () => {
     const [backgroundState, setBackgroundState] = useState("");
 
     // state updater
-    const onChangeHandler = (e, setValue) => {
-        console.log(e.target);
-        setValue(e.target.value);
+  const onChangeHandler = (e, setValue) => {
+    console.log(e.target);
+    setValue(e.target.value);
+  }
+
+  const onSubmitHandler = async (e) => {
+    e.preventDefault();
+    const newBoard = {
+        title: titleState,
+        image: backgroundState
+    };
+
+    console.log("New Board, yo: ", newBoard);
+
+    const options = {
+        method: 'POST',
+        headers: {
+            "Content-Type": "application/json"
+        }, 
+        body: JSON.stringify(newBoard)
     }
 
-    const onSubmitHandler = async (e) => {
-        e.preventDefault();
-        const newBoard = {
-            title: titleState,
-            background: backgroundState
-    };
-    console.log("New Board, yo: ", newBoard);
-    }
-    
+    const responseData = await fetch("https://calypso-back-end.onrender.com/boards", options);
+
+    const newBoardObj = await responseData.json();
+    console.group(newBoardObj);
+
+  };
     // form to create new Board
     return (
       <div className="newboard">

--- a/frontend/src/components/NewBoard.js
+++ b/frontend/src/components/NewBoard.js
@@ -2,23 +2,25 @@
 import { Form, Button } from 'react-bootstrap';
 import { useState } from 'react';
 
+
 const NewBoard = () => {
 
-    // set up board and state
-    const [titleState, setTitleState] = useState("");
-    const [backgroundState, setBackgroundState] = useState("");
+  // set up board and state
+  const [titleState, setTitleState] = useState("");
+  // const [backgroundState, setBackgroundState] = useState("");
 
-    // state updater
+  // state updater
   const onChangeHandler = (e, setValue) => {
     console.log(e.target);
     setValue(e.target.value);
   }
 
+  // on submit
   const onSubmitHandler = async (e) => {
     e.preventDefault();
     const newBoard = {
         title: titleState,
-        image: backgroundState
+        // image: backgroundState
     };
 
     console.log("New Board, yo: ", newBoard);
@@ -29,7 +31,7 @@ const NewBoard = () => {
             "Content-Type": "application/json"
         }, 
         body: JSON.stringify(newBoard)
-    }
+    };
 
     const responseData = await fetch("https://calypso-back-end.onrender.com/boards", options);
 
@@ -37,36 +39,36 @@ const NewBoard = () => {
     console.group(newBoardObj);
 
   };
-    // form to create new Board
-    return (
-      <div className="newboard">
-        <Form onSubmit={onSubmitHandler}>
-          <Form.Group>
-            <Form.Label>Title</Form.Label>
-            <Form.Control
-              type="text"
-              value={titleState}
-              name="title"
-              placeholder="Enter title"
-              onChange={(e) => onChangeHandler(e, setTitleState)}
-            />
-          </Form.Group>
-          <Form.Group>
-            <Form.Label>Background</Form.Label>
-            <Form.Control
-              type="text"
-              value={backgroundState}
-              name="background"
-              placeholder="Enter background"
-              onChange={(e) => onChangeHandler(e, setBackgroundState)}
-            />
-          </Form.Group>
-          <Button variant="primary" type="submit">
-            Create a New Board
-          </Button>
-        </Form>
-      </div>
-    );
+  // form to create new Board
+  return (
+    <div className="newboard">
+      <Form onSubmit={onSubmitHandler}>
+        <Form.Group>
+          <Form.Label>Title</Form.Label>
+          <Form.Control
+            type="text"
+            value={titleState}
+            name="board-title"
+            placeholder="Enter title"
+            onChange={(e) => onChangeHandler(e, setTitleState)}
+          />
+        </Form.Group>
+        {/* <Form.Group>
+          <Form.Label>Background</Form.Label>
+          <Form.Control
+            type="text"
+            value={backgroundState}
+            name="background"
+            placeholder="Enter background"
+            onChange={(e) => onChangeHandler(e, setBackgroundState)}
+          />
+        </Form.Group> */}
+        <Button variant="primary" type="submit">
+          Create a New Board
+        </Button>
+      </Form>
+    </div>
+  );
 };
 
 export default NewBoard;

--- a/frontend/src/components/NewCalCard.js
+++ b/frontend/src/components/NewCalCard.js
@@ -2,26 +2,41 @@
 import { Form, Button } from 'react-bootstrap';
 import { useState } from 'react';
 
-const NewCalCard = () => {
-
+const NewCalCard = ({id}) => {
+    console.log(id);
     // set up cards and states
     const [titleState, setTitleState] = useState("");
-    const [columnState, setColumnState] = useState("");
+    const [taskState, setTaskState] = useState("");
 
     // state updater
     const onChangeHandler = (e, setValue) => {
-        console.log(e.target);
-        setValue(e.target.value);
-    }
-
-    const onSubmitHandler = async (e) => {
-        e.preventDefault();
-        const newCalCard = {
-            title: titleState,
-            column: columnState
+      console.log(e.target);
+      setValue(e.target.value);
     };
-    console.log("New Card, yo: ", newCalCard);
-    }
+
+    // on submit
+    const onSubmitHandler = async (e) => {
+      e.preventDefault();
+      const newCalCard = {
+          title: titleState,
+          task: taskState
+      };
+      console.log("New Card, yo: ", newCalCard);
+
+      // post backend
+      const options = {
+        method: 'POST',
+        headers: {
+            "Content-Type": "application/json"
+        }, 
+        body: JSON.stringify(newCalCard)
+      };
+
+      const responseData = await fetch(`https://calypso-back-end.onrender.com/boards/${id}/cards`, options);
+
+      const newCardObj = await responseData.json();
+      console.group(newCardObj);
+    }; // end submit
     
     // form to create new Card
     return (
@@ -31,8 +46,8 @@ const NewCalCard = () => {
             <Form.Label>Title</Form.Label>
             <Form.Control
               type="text"
-              value={setTitleState}
-              name="calCard"
+              value={titleState}
+              name="card-title"
               placeholder="Enter Card Title"
               onChange={(e) => onChangeHandler(e, setTitleState)}
             />

--- a/frontend/src/components/NewCalCard.js
+++ b/frontend/src/components/NewCalCard.js
@@ -2,11 +2,14 @@
 import { Form, Button } from 'react-bootstrap';
 import { useState } from 'react';
 
-const NewCalCard = ({id}) => {
-    console.log(id);
+
+const NewCalCard = ({ id }) => {
+
+    console.log('id: ', id);
+
     // set up cards and states
     const [titleState, setTitleState] = useState("");
-    const [taskState, setTaskState] = useState("");
+    // const [taskState, setTaskState] = useState("");
 
     // state updater
     const onChangeHandler = (e, setValue) => {
@@ -19,22 +22,23 @@ const NewCalCard = ({id}) => {
       e.preventDefault();
       const newCalCard = {
           title: titleState,
-          task: taskState
+          // tasks: taskState
       };
       console.log("New Card, yo: ", newCalCard);
 
       // post backend
-      const options = {
-        method: 'POST',
-        headers: {
-            "Content-Type": "application/json"
-        }, 
-        body: JSON.stringify(newCalCard)
-      };
+      // const options = {
+      //   method: 'POST',
+      //   headers: {
+      //       "Content-Type": "application/json"
+      //   }, 
+      //   body: JSON.stringify(newCalCard)
+      // };
 
-      const responseData = await fetch(`https://calypso-back-end.onrender.com/boards/${id}/cards`, options);
+      // const responseData = await fetch(`https://calypso-back-end.onrender.com/boards/${id}/cards`, options);
+      const newCardObj = {'title': titleState, 'tasks': []};
 
-      const newCardObj = await responseData.json();
+      // const newCardObj = await responseData.json();
       console.group(newCardObj);
     }; // end submit
     

--- a/frontend/src/components/NewTask.js
+++ b/frontend/src/components/NewTask.js
@@ -6,8 +6,6 @@ const NewTask = () => {
     
     // set up tasks and states
     const [task, setTask] = useState("");
-    const [cardID, setCardID] = useState("")
-    const [rowState, setRowState] = useState("");
 
     // state updater
     const onChangeHandler = (e, setValue) => {
@@ -17,9 +15,7 @@ const NewTask = () => {
     const onSubmitHandler = async (e) => {
         e.preventDefault();
         const newTask = {
-            task: task,
-            row: rowState,
-            card: cardID
+            task: task
     };
     console.log("New Task, yo: ", newTask);
     }

--- a/frontend/src/pages/Boards.js
+++ b/frontend/src/pages/Boards.js
@@ -1,21 +1,23 @@
 // import the stuff you need
-import { useEffect, useState } from "react";
+import { useEffect, useState } from 'react';
 import 'bootstrap/dist/css/bootstrap.min.css';
 import { Card, Container, Button, Modal } from 'react-bootstrap';
 import Board from "../components/Board";
 import NewBoard from "../components/NewBoard";
+import BoardIcon from '../components/BoardIcon';
 
 const Boards = () => {
     
     // get the boards
     const [boards, setBoards] = useState(null);
-    const URL = "";
+    const URL = "https://calypso-back-end.onrender.com/boards/";
     useEffect(() => {
         console.log("boards useEffect ran");
         const fetchBoards = async() => {
             try {
                 let responseData = await fetch(URL);
                 let allBoards = await responseData.json();
+                console.log(responseData);
                 console.log(allBoards);
                 setBoards(allBoards);
             } catch (error) {}
@@ -24,15 +26,17 @@ const Boards = () => {
     }, []);
 
     // list the boards
-    let boardList;
+    // let boardList;
 
-    if (boards) {
-        boardList = boards.map((board, index) => {
-          return (
-              <Board key={index} board={board} />
-          );
-        });
-    };
+    // if (boards) {
+    //     console.log('boards! ', boards)
+    //     // boardList = boards.map((board, index) => {
+    //       return (
+    //           <BoardIcon boards={boards} />
+    //       );
+    //     // });
+    // };
+    // console.log(boardList)
 
     // for add new board modal
     const [showModal, setShowModal] = useState(false);
@@ -48,24 +52,9 @@ const Boards = () => {
         <div>
             <h1>Boards Page</h1>
             <h3>My Boards</h3>
+            
             {/* existing boards */}
-            <Container style={{ display: 'flex', flexDirection: 'row' }}>
-                <Card style={{ flex: 1 }}>
-                <Card.Title>Board Name</Card.Title>
-                    <Card.Img src="" />
-                <h3>image</h3>
-                </Card>
-                <Card style={{ flex: 1 }}>
-                <Card.Title>Board Name</Card.Title>
-                    <Card.Img src="" />
-                <h3>image</h3>
-                </Card>
-                <Card style={{ flex: 1 }}>
-                <Card.Title>Board Name</Card.Title>
-                    <Card.Img src="" />
-                <h3>image</h3>
-                </Card>
-            </Container>
+            {boards ? <BoardIcon boards={boards} /> : <h2>LOADING.. </h2>}
 
             {/* new board form */}
             <Button variant="primary" onClick={handleShowModal}>

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -1,7 +1,0 @@
-import { createStore } from 'redux';
-
-const reducer = () => {}
-
-const store = createStore(reducer);
-
-export default store;


### PR DESCRIPTION
the get and post route work, so now when you go to /boards it lists the boards from the database. I created a new board icon component to display these on the /boards page. If you click on one of the boards, it will take you to its show page. I need to fix the 'add new' modal on the /boards page because it doesn't close after it creates a new board, I have to exit out of it and refresh the page for the new board icon to show up. hopefully can do the 'add card' and 'add task' routes tomorrow.